### PR TITLE
Change docker-compose.yml version to 2, add logging settings

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,12 @@
-version: '3'
+version: "2"
 services:
   monit:
     image: "kijart/monit"
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "5"
     ports:
       - 2812:2812
     volumes:


### PR DESCRIPTION
- `docker-compose.yml` 2.0 and 3.0+ have different compatibility with different Docker versions and it's [preferable](https://stackoverflow.com/a/53636006/961092) to use 2.0 when you don't use swarm;
- without logging settings in `docker-compose.yml` Monit container could clog host machine disk space with log in a long-running scenario